### PR TITLE
Create empty public directory and git ignore it

### DIFF
--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Seems the example requires a public directory to be created before saving bundle.js to it.
